### PR TITLE
将 istanbul 版本提升为 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "html-webpack-plugin": "^2.30.1",
     "http-proxy-middleware": "^0.17.3",
     "is-plain-object": "^2.0.3",
-    "istanbul": "^0.4.5",
+    "istanbul": "^1.0.0-alpha",
     "less": "^2.7.1",
     "less-loader": "^4.0.3",
     "lodash.pullall": "^4.2.0",


### PR DESCRIPTION
解决无法正常显示测试覆盖率的问题